### PR TITLE
Update model_spec.in

### DIFF
--- a/{{cookiecutter.package_name}}/src/{{cookiecutter.package_name}}/model_specifications/model_spec.in
+++ b/{{cookiecutter.package_name}}/src/{{cookiecutter.package_name}}/model_specifications/model_spec.in
@@ -19,7 +19,7 @@ configuration:
         extrapolate: False
     randomness:
         map_size: 1_000_000
-        key_columns: ['entrance_time']
+        key_columns: ['entrance_time', 'age']
         random_seed: 0
     time:
         start:


### PR DESCRIPTION
Entrance time is insufficient to uniquely identify simulants across simulations.