### PR TITLE
Add .zenodo.json and remove AUTHORS.rst

### DIFF
--- a/{{cookiecutter.package_name}}/.zenodo.json
+++ b/{{cookiecutter.package_name}}/.zenodo.json
@@ -1,0 +1,10 @@
+{
+    "license": "BSD-3-Clause",
+    "title": "ihmeuw/{{ cookiecutter.package_name }}: Archival release",
+    "upload_type": "software",
+    "creators": [
+
+    ],
+    "access_right": "open",
+    "description": "<p>Archival release of simulation software.</p>"
+}

--- a/{{cookiecutter.package_name}}/.zenodo.json
+++ b/{{cookiecutter.package_name}}/.zenodo.json
@@ -3,8 +3,12 @@
     "title": "ihmeuw/{{ cookiecutter.package_name }}: Archival release",
     "upload_type": "software",
     "creators": [
-
+//        {
+//            "orcid": "0000-0000-0000-0000",
+//            "affiliation": "Institute for Health Metrics and Evaluation",
+//            "name": "TODO: Add authors names, affiliation, and orcid (if applicable) to `creators` array"
+//        }
     ],
     "access_right": "open",
-    "description": "<p>Archival release of simulation software.</p>"
+    "description": "<p>TODO: add description (e.g., Archival release of simulation software.)</p>"
 }

--- a/{{cookiecutter.package_name}}/AUTHORS.rst
+++ b/{{cookiecutter.package_name}}/AUTHORS.rst
@@ -1,9 +1,0 @@
-Authors
-======
-
-LEAD ENGINEER:
-RESEARCHER:
-DATA ANALYST:
-
-Contributors
--------------

--- a/{{cookiecutter.package_name}}/MANIFEST.in
+++ b/{{cookiecutter.package_name}}/MANIFEST.in
@@ -1,4 +1,3 @@
-include AUTHORS.rst
 include LICENSE
 include README.rst
 


### PR DESCRIPTION
This change removes the AUTHORS.rst file in favor the the .zenodo.json file, which allows Zenodo to automatically publish releases made in Github, once enabled.