### PR TITLE
Add PR template for research repositories

### DIFF
--- a/{{cookiecutter.package_name}}/.github/pull_request_template.md
+++ b/{{cookiecutter.package_name}}/.github/pull_request_template.md
@@ -8,15 +8,13 @@
 - *JIRA issue*: <!-- [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ) -->
 - *Research reference*: <!--Link to research documentation for code -->
 
-<!-- Change description – why, what, anything unexplained by the above -->
+<!-- 
+Change description – why, what, anything unexplained by the above.
+Include guidance to reviewers if changes are complex.
+--> 
 
 ### Verification and Testing
 <!--
 Details on how code was verified. Consider: plots, images, (small) csv files.
 -->
 
-<!--
-For engineering review:
-    Discussion topic: how much detail?
-    Discussion topic: what should be included in testing?
--->

--- a/{{cookiecutter.package_name}}/.github/pull_request_template.md
+++ b/{{cookiecutter.package_name}}/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Title: Summary, imperative, start upper case, don't end with a period
+<!-- Ideally, <=50 chars. 50 chars is here..: -->
+
+### Description
+<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
+- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
+                   post-processing, cleanup/refactor/cosmetic, other/misc -->
+- *JIRA issue*: <!-- [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ) -->
+- *Research reference*: <!--Link to research documentation for code -->
+
+<!-- Change description – why, what, anything unexplained by the above -->
+
+### Verification and Testing
+<!--
+Details on how code was verified. Consider: plots, images, (small) csv files.
+-->
+
+<!--
+For engineering review:
+    Discussion topic: how much detail?
+    Discussion topic: what should be included in testing?
+-->

--- a/{{cookiecutter.package_name}}/.github/pull_request_template.md
+++ b/{{cookiecutter.package_name}}/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 ### Description
 <!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
 - *Category*: <!-- one of bugfix, data artifact, implementation, observers,
-                   post-processing, cleanup/refactor/cosmetic, other/misc -->
+                   post-processing, refactor, revert, test, release, other/misc -->
 - *JIRA issue*: <!-- [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ) -->
 - *Research reference*: <!--Link to research documentation for code -->
 


### PR DESCRIPTION
## Add PR template for research repo template
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: other/misc
- *JIRA issue*: [MIC-2452](https://jira.ihme.washington.edu/browse/MIC-2452)

This change adds a PR template for research repos generated via 
`vadmin`. There are HTML comments for guidance and discussion notes.

### Verification and Testing
I am using the template here, and have a to-be-completed test using
`vadmin` and `vivarium_research_template` repos to create a repo,
then observe that the template is picked up by the GitHub UI.
