### PR TITLE
Mic-4382/Move lint before test

### DIFF
--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -71,14 +71,14 @@ jobs:
           pushd vivarium_inputs
           pip install .
           popd
+      - name: Lint
+        run: |
+          pip install black==22.3.0 isort
+          black . --check -v
+          isort . --check -v
       - name: Install dependencies
         run: |
           pip install .[test]
       - name: Test
         run: |
           pytest ./tests
-      - name: Lint
-        run: |
-          pip install black==22.1.0 isort
-          black . --check -v
-          isort . --check -v

--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -71,12 +71,12 @@ jobs:
           pushd vivarium_inputs
           pip install .
           popd
+      - name: Install dependencies
       - name: Lint
         run: |
           pip install black==22.3.0 isort
           black . --check -v
           isort . --check -v
-      - name: Install dependencies
         run: |
           pip install .[test]
       - name: Test

--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -72,13 +72,13 @@ jobs:
           pip install .
           popd
       - name: Install dependencies
+        run: |
+          pip install .[test]
       - name: Lint
         run: |
           pip install black==22.3.0 isort
           black . --check -v
           isort . --check -v
-        run: |
-          pip install .[test]
       - name: Test
         run: |
           pytest ./tests


### PR DESCRIPTION
## Mic-4382/Move lint before test
### Moves linting before tests in builds.
- *Category*: Other
- *JIRA issue*: [MIC-4382](https://jira.ihme.washington.edu/browse/MIC-4382)

### Changes and notes
-moves linting before tests in builds.

### Testing


