### PR TITLE
Mic-4379/Add schedule build to CI

### DIFF
--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -1,9 +1,14 @@
 # -----------------------------------------------------------------------------
-#   - invoked on push, pull_request, or manual trigger
-#   - test under at least 4 versions of python
+#   - invoked on push, pull_request, manual trigger, or schedule
+#   - test under at least 3 versions of python
 # -----------------------------------------------------------------------------
 name: build
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule: 
+    - cron: "0 8 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
## Mic-4379/Add schedule build to CI

### Adds nightly build to github actions.
- *Category*: CI
- *JIRA issue*: [MIC-4379](https://jira.ihme.washington.edu/browse/MIC-4379)

### Changes and notes
-Adds schedule build to run at 1AM

### Testing
All tests pass
