### PR TITLE
add setuptools-scm to template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,4 @@ venv.bak/
 .idea/
 
 # Version file
-src/*/_version.py
+src/vivarium_research_template/_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # pycharm
 .idea/
+
+# Version file
+src/*/_version.py

--- a/{{cookiecutter.package_name}}/.gitignore
+++ b/{{cookiecutter.package_name}}/.gitignore
@@ -125,3 +125,6 @@ dmypy.json
 
 # Pycharm project settings
 .idea/
+
+# Version file
+src/*/_version.py

--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -29,6 +29,8 @@ if __name__ == "__main__":
         "tables",
     ]
 
+    setup_requires = ["setuptools_scm"]
+
     data_requirements = ["vivarium_inputs[data]=={{cookiecutter.vivarium_inputs_version}}"]
     cluster_requirements = ["vivarium_cluster_tools=={{cookiecutter.vivarium_cluster_tools_version}}"]
     test_requirements = ["pytest"]
@@ -36,7 +38,6 @@ if __name__ == "__main__":
 
     setup(
         name=about["__title__"],
-        version=about["__version__"],
         description=about["__summary__"],
         long_description=long_description,
         license=about["__license__"],
@@ -54,6 +55,12 @@ if __name__ == "__main__":
             "dev": test_requirements + cluster_requirements + lint_requirements,
         },
         zip_safe=False,
+        use_scm_version={
+            "write_to": "src/{{cookiecutter.package_name}}/_version.py",
+            "write_to_template": '__version__ = "{version}"\n',
+            "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
+        },
+        setup_requires=setup_requires,
         entry_points="""
             [console_scripts]
             make_artifacts={{cookiecutter.package_name}}.tools.cli:make_artifacts

--- a/{{cookiecutter.package_name}}/src/{{cookiecutter.package_name}}/__about__.py
+++ b/{{cookiecutter.package_name}}/src/{{cookiecutter.package_name}}/__about__.py
@@ -1,13 +1,16 @@
 __all__ = [
-    "__title__", "__summary__", "__uri__", "__version__", "__author__",
-    "__email__", "__license__", "__copyright__",
+    "__title__",
+    "__summary__",
+    "__uri__",
+    "__author__",
+    "__email__",
+    "__license__",
+    "__copyright__",
 ]
 
 __title__ = "{{cookiecutter.package_name}}"
 __summary__ = "{{cookiecutter.package_description}}"
 __uri__ = "{{cookiecutter.package_url}}"
-
-__version__ = "{{cookiecutter.package_version}}"
 
 __author__ = "The vivarium developers"
 __email__ = "vivarium.dev@gmail.com"


### PR DESCRIPTION
## Add setuptools-scm to template
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4243

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
this adds setuptools-scm to the repo template. The primary
motivation here is to get the dynamic versions of model repos
(i.e. version \<latest tag\> \<distance to tag\> \<working directory state\>)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

