### PR TITLE
Update readme for Python 3.11 and make_specs deprecation

### DIFF
--- a/{{cookiecutter.package_name}}/README.rst
+++ b/{{cookiecutter.package_name}}/README.rst
@@ -107,15 +107,12 @@ You'll find six directories inside the main
 Running Simulations
 -------------------
 
-With your conda environment active, the first step to running simulations
-is making the model specification files.
-
 Before running a simulation, you should have a model specification file.
 A model specification is a complete description of a vivarium model in
 a yaml format.  An example model specification is provided with this repository
 in the ``model_specifications`` directory.
 
-With this model specification file, you can then run simulations by, e.g.::
+With this model specification file and your conda environment active, you can then run simulations by, e.g.::
 
    ({{ cookiecutter.package_name }}) :~$ simulate run -v /<REPO_INSTALLATION_DIRECTORY>/{{ cookiecutter.package_name }}/src/{{ cookiecutter.package_name }}/model_specifications/model_spec.yaml
 

--- a/{{cookiecutter.package_name}}/README.rst
+++ b/{{cookiecutter.package_name}}/README.rst
@@ -23,7 +23,7 @@ Once you have all three installed, you should open up your normal shell
 You'll then make an environment, clone this repository, then install
 all necessary requirements as follows::
 
-  :~$ conda create --name={{ cookiecutter.package_name }} python=3.8
+  :~$ conda create --name={{ cookiecutter.package_name }} python=3.11
   ...conda will download python and base dependencies...
   :~$ conda activate {{ cookiecutter.package_name }}
   ({{ cookiecutter.package_name }}) :~$ git clone https://github.com/ihmeuw/{{ cookiecutter.package_name }}.git
@@ -108,19 +108,16 @@ Running Simulations
 -------------------
 
 With your conda environment active, the first step to running simulations
-is making the model specification files.  A model specification is a
-complete description of a vivarium model. The command to generate model
-specifications is installed with this repository and it can be run
-from any directory.::
+is making the model specification files.
 
-  ({{ cookiecutter.package_name }}) :~$ make_specs -v
-  2020-06-18 18:18:28.311 | 0:00:00.679701 | build_model_specifications:48 - Writing model spec(s) to "/REPO_INSTALLATION_DIRECTORY/{{ cookiecutter.package_name }}/src/{{ cookiecutter.package_name }}/model_specifications"
+Before running a simulation, you should have a model specification file.
+A model specification is a complete description of a vivarium model in
+a yaml format.  An example model specification is provided with this repository
+in the ``model_specifications`` directory.
 
-As the log message indicates, the model specifications will be written to
-the ``model_specifications`` subdirectory in this repository. You can then
-run simulations by, e.g.::
+With this model specification file, you can then run simulations by, e.g.::
 
-   ({{ cookiecutter.package_name }}) :~$ simulate run -v /<REPO_INSTALLATION_DIRECTORY>/{{ cookiecutter.package_name }}/src/{{ cookiecutter.package_name }}/model_specifications/china.yaml
+   ({{ cookiecutter.package_name }}) :~$ simulate run -v /<REPO_INSTALLATION_DIRECTORY>/{{ cookiecutter.package_name }}/src/{{ cookiecutter.package_name }}/model_specifications/model_spec.yaml
 
 The ``-v`` flag will log verbosely, so you will get log messages every time
 step. For more ways to run simulations, see the tutorials at


### PR DESCRIPTION
## Update readme for Python 3.11 and make_specs deprecation

### Description

- *Category*: documentation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-2421

### Changes and notes
- Updates readme for deprecation of `make_specs` in favor of direct editing of the yaml
- Updates the Python version expected for the environment to 3.11.


### Testing
Visual inspection of parsed rst.

