### PR TITLE
stop writing results to hdf

### DIFF
--- a/{{cookiecutter.package_name}}/src/{{cookiecutter.package_name}}/results_processing/process_results.py
+++ b/{{cookiecutter.package_name}}/src/{{cookiecutter.package_name}}/results_processing/process_results.py
@@ -49,7 +49,6 @@ class MeasureData(NamedTuple):
 
     def dump(self, output_dir: Path):
         for key, df in self._asdict().items():
-            df.to_hdf(output_dir / f'{key}.hdf', key=key)
             df.to_csv(output_dir / f'{key}.csv')
 
 


### PR DESCRIPTION
## Stop writing results to hdf
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4764

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> RT seems to only use the results in csv format and so there is no
reason to write to hdf as well. Further, there seems to be intermittent
problems where `transition_count.hdf` datasets cannot be loaded
(even though the corresponding *.csv can be).

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
na
