### PR TITLE
Add automatic defaults version numbers

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,8 +1,8 @@
 {
     "package_name": "",
     "current_year": "",
-    "package_version": "1.0.0",
-    "package_description": "Research repository for the {{cookiecutter.package_name}} project.",
+    "package_version": "0.0.1",
+    "package_description": "Vivarium simulation model for the {{cookiecutter.package_name}} project.",
     "package_url": "https://github.com/ihmeuw/{{cookiecutter.package_name}}",
     "ssh_url": "git@github.com:ihmeuw/{{cookiecutter.package_name}}.git",
     "vivarium_version": "",

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,6 +1,7 @@
 import os
 import json
 import requests
+print("DEBUG: pre_gen_project.py is running...")
 
 def get_latest_version(package_name):
     """Fetch the latest version of a package from PyPI."""

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,41 @@
+import os
+import json
+import requests
+
+def get_latest_version(package_name):
+    """Fetch the latest version of a package from PyPI."""
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()
+        return data["info"]["version"]
+    else:
+        raise ValueError(f"Could not fetch version for {package_name}")
+
+def main():
+    """Update cookiecutter context dynamically."""
+    # Fetch versions for the required packages
+    packages = {
+        "vivarium": "vivarium",
+        "vivarium_public_health": "vivarium-public-health",
+        "vivarium_cluster_tools": "vivarium-cluster-tools",
+        "vivarium_inputs": "vivarium-inputs",
+        "gbd_mapping": "gbd-mapping",
+    }
+    versions = {key: get_latest_version(value) for key, value in packages.items()}
+
+    # Update the context dynamically
+    context_file = os.path.join(os.getcwd(), "cookiecutter.json")
+    with open(context_file, "r") as file:
+        context = json.load(file)
+
+    # Inject the fetched versions into the context
+    for key, version in versions.items():
+        context[f"{key}_version"] = version
+
+    # Write updated context back to cookiecutter.json
+    with open(context_file, "w") as file:
+        json.dump(context, file, indent=4)
+
+if __name__ == "__main__":
+    main()

--- a/hooks/pre_prompt.py
+++ b/hooks/pre_prompt.py
@@ -1,5 +1,6 @@
 import os
 import json
+from datetime import datetime
 import requests
 
 def get_latest_version(package_name):
@@ -30,7 +31,6 @@ def main():
         context = json.load(file)
 
     # Set default for current year if not provided
-    from datetime import datetime
     context["current_year"] = str(datetime.now().year)
 
     # Inject the fetched versions into the context

--- a/hooks/pre_prompt.py
+++ b/hooks/pre_prompt.py
@@ -1,7 +1,7 @@
 import os
 import json
 import requests
-print("DEBUG: pre_gen_project.py is running...")
+print("DEBUG: pre_prompt.py is running...")
 
 def get_latest_version(package_name):
     """Fetch the latest version of a package from PyPI."""

--- a/hooks/pre_prompt.py
+++ b/hooks/pre_prompt.py
@@ -1,7 +1,6 @@
 import os
 import json
 import requests
-print("DEBUG: pre_prompt.py is running...")
 
 def get_latest_version(package_name):
     """Fetch the latest version of a package from PyPI."""
@@ -14,7 +13,7 @@ def get_latest_version(package_name):
         raise ValueError(f"Could not fetch version for {package_name}")
 
 def main():
-    """Update cookiecutter context dynamically."""
+    """Update cookiecutter context dynamically with current package versions."""
     # Fetch versions for the required packages
     packages = {
         "vivarium": "vivarium",
@@ -29,6 +28,10 @@ def main():
     context_file = os.path.join(os.getcwd(), "cookiecutter.json")
     with open(context_file, "r") as file:
         context = json.load(file)
+
+    # Set default for current year if not provided
+    from datetime import datetime
+    context["current_year"] = context.get("current_year", str(datetime.now().year))
 
     # Inject the fetched versions into the context
     for key, version in versions.items():

--- a/hooks/pre_prompt.py
+++ b/hooks/pre_prompt.py
@@ -31,7 +31,7 @@ def main():
 
     # Set default for current year if not provided
     from datetime import datetime
-    context["current_year"] = context.get("current_year", str(datetime.now().year))
+    context["current_year"] = str(datetime.now().year)
 
     # Inject the fetched versions into the context
     for key, version in versions.items():


### PR DESCRIPTION
## Title: Add automatic defaults version numbers


### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->feature
- *JIRA issue*: none

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> It is annoying to have to look up the current version numbers for all the vivarium-related packages when using this cookiecutter script, so ChatGPT and I came up with this enhancement.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
```
(base) abie@LT-MJ0L9VRK:~$ cookiecutter git@github.com:ihmeuw/vivarium_research_template.git --checkout auto_version_numbers
You've downloaded /home/abie/.cookiecutters/vivarium_research_template before. Is it okay to delete and re-download it?
[y/n] (y):
  [1/11] package_name (): vivarium_eye_vessels
  [2/11] current_year (2024):
  [3/11] package_version (0.0.1):
  [4/11] package_description (Vivarium simulation model for the vivarium_eye_vessels project.):
  [5/11] package_url (https://github.com/ihmeuw/vivarium_eye_vessels):
  [6/11] ssh_url (git@github.com:ihmeuw/vivarium_eye_vessels.git):
  [7/11] vivarium_version (3.2.10):
  [8/11] vivarium_public_health_version (3.1.3):
  [9/11] vivarium_cluster_tools_version (2.1.1):
  [10/11] vivarium_inputs_version (5.2.2):
  [11/11] gbd_mapping_version (4.1.2):
```
